### PR TITLE
Get response object in exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.0] - Sept 2021
+* get response object in exceptions
+
 ## [3.2.0] - Jun 2021
 * added few more api custom exceptions
 * minor fixes

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ except Exception as ex:
     print(f"There was a problem: {ex}")
 ```
 
+## Note on Exceptions
+- `HotRechargeException` is the base class for all exceptions
+- All exceptions are subclasses of `HotRechargeException` 
+- All exceptions have a `message` property that contains the error message
+- All exceptions have a `response` property that contains the response object(which is a `Munch`). In some cases this will be `None`, so dont get mad if you see `None`😁.
+- One of the best use cases of the `response` property is when a `PendingZesaTransaction` exception gets raised. you can save `rechargeID`, then you can use it later to query the transaction status. 
+
+
 ## Support 🤿
 - This is not an official hot-recharge python library
 - I initiated, develop and maintain this library on my own spare time 

--- a/hotrecharge/HotRecharge.py
+++ b/hotrecharge/HotRecharge.py
@@ -19,7 +19,7 @@ class HotRecharge:
     """
     Hot Recharge Python Api Library
     __author__  Donald Chinhuru
-    __version__ 3.2.0
+    __version__ 3.3.0
     __name__    Hot Recharge Api
     """
 

--- a/hotrecharge/HotRechargeExcHandler.py
+++ b/hotrecharge/HotRechargeExcHandler.py
@@ -27,35 +27,35 @@ class ApiExceptionHandler:
         if hasattr(self.response, "ReplyCode"):
             if int(self.response.ReplyCode) != 2:
                 raise self.__switcher(_msg).get(
-                    int(self.response.ReplyCode), HotRechargeException(_msg)
+                    int(self.response.ReplyCode), HotRechargeException(_msg, self.response)
                 )
 
         if self.is_429_401:
-            raise self.__switcher(_msg).get(self.is_429_401, HotRechargeException(_msg))
+            raise self.__switcher(_msg).get(self.is_429_401, HotRechargeException(_msg, self.response))
 
         else:
             # raise default error
-            raise HotRechargeException(_msg)
+            raise HotRechargeException(_msg, self.response)
 
     def __switcher(self, message: str) -> dict:
         api_exception_mapper = {
-            4: PendingZesaTransaction(message),
-            206: PrepaidPlatformFail(message),
-            208: InsufficientBalance(message),
-            209: OutOfPinStock(message),
-            210: PrepaidPlatformFail(message),
-            216: DuplicateRequestException(message),
-            217: InvalidContact(message),
-            218: AuthorizationError(message),
-            219: WebServiceException(message),
-            220: AuthorizationError(message),
-            221: BalanceRequestError(message),
-            222: RechargeAmountLimit(message),
+            4: PendingZesaTransaction(message, self.response),
+            206: PrepaidPlatformFail(message, self.response),
+            208: InsufficientBalance(message, self.response),
+            209: OutOfPinStock(message, self.response),
+            210: PrepaidPlatformFail(message, self.response),
+            216: DuplicateRequestException(message, self.response),
+            217: InvalidContact(message, self.response),
+            218: AuthorizationError(message, self.response),
+            219: WebServiceException(message, self.response),
+            220: AuthorizationError(message, self.response),
+            221: BalanceRequestError(message, self.response),
+            222: RechargeAmountLimit(message, self.response),
             # -------- http status code -----------
-            401: AuthorizationError(message),
-            429: DuplicateReference(message),
+            401: AuthorizationError(message, self.response),
+            429: DuplicateReference(message, self.response),
             # -------------------------------------
-            800: TransactionNotFound(message),
+            800: TransactionNotFound(message, self.reponse),
         }
 
         return api_exception_mapper

--- a/hotrecharge/HotRechargeException.py
+++ b/hotrecharge/HotRechargeException.py
@@ -7,6 +7,8 @@
     - force to throw exceptions when api response has error
 """
 
+from munch import Munch
+
 
 class HotRechargeException(Exception):
     """HotRechargeException base exception for api exceptions
@@ -16,7 +18,10 @@ class HotRechargeException(Exception):
                                           you can use this base class if you are not sure which specific exception to target although its not good practise
     """
 
-    pass
+    def __init__(self, message, response:Munch = None):
+        super().__init__(message)
+        self.message = message
+        self.response = response
 
 
 class DuplicateReference(HotRechargeException):

--- a/hotrecharge/__init__.py
+++ b/hotrecharge/__init__.py
@@ -4,5 +4,5 @@ from .HotRecharge import HotRecharge, HRAuthConfig
 from .HotRechargeException import *
 
 __author__ = "Donald Chinhuru"
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 __name__ = "hot-recharge"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hot-recharge",
-    version="3.2.0",
+    version="3.3.0",
     author="Donald Chinhuru",
     author_email="donychinhuru@gmail.com",
     description="perform hot-recharge services with hot-recharge library programmatically",


### PR DESCRIPTION
Whenever an exception gets raised users can access the *response object* through the `response` attribute

Lets say a user tries to buy electricity but a `PendingZesaTransaction` exception gets raised, you can access response object, get recharge id then use it later:

```python
from hotrecharge.HotRechargeException import *
...
...
...
try:
     response = api.rechargeZesa(400.0, "077XXXXXXX", "01XXXXXXXXX")
except PendingZesaTransaction  as ex:
     response = ex.response
     rechargeId = response["RechargeID"]

    # Save Recharge ID somewhere for later use
```

You can save any info in the response object that you might find useful