### PR TITLE
Fix 'ApiExceptionHandler' object has no attribute 'reponse'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.1] - Sept 2021
+* Fix 'ApiExceptionHandler' object has no attribute 'reponse'
+
 ## [3.3.0] - Sept 2021
 * get response object in exceptions
 

--- a/hotrecharge/HotRecharge.py
+++ b/hotrecharge/HotRecharge.py
@@ -19,7 +19,7 @@ class HotRecharge:
     """
     Hot Recharge Python Api Library
     __author__  Donald Chinhuru
-    __version__ 3.3.0
+    __version__ 3.3.1
     __name__    Hot Recharge Api
     """
 

--- a/hotrecharge/HotRechargeExcHandler.py
+++ b/hotrecharge/HotRechargeExcHandler.py
@@ -55,7 +55,7 @@ class ApiExceptionHandler:
             401: AuthorizationError(message, self.response),
             429: DuplicateReference(message, self.response),
             # -------------------------------------
-            800: TransactionNotFound(message, self.reponse),
+            800: TransactionNotFound(message, self.response),
         }
 
         return api_exception_mapper

--- a/hotrecharge/__init__.py
+++ b/hotrecharge/__init__.py
@@ -4,5 +4,5 @@ from .HotRecharge import HotRecharge, HRAuthConfig
 from .HotRechargeException import *
 
 __author__ = "Donald Chinhuru"
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 __name__ = "hot-recharge"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hot-recharge",
-    version="3.3.0",
+    version="3.3.1",
     author="Donald Chinhuru",
     author_email="donychinhuru@gmail.com",
     description="perform hot-recharge services with hot-recharge library programmatically",


### PR DESCRIPTION
```
 800: TransactionNotFound(message, self.reponse),
AttributeError: 'ApiExceptionHandler' object has no attribute 'reponse'
```